### PR TITLE
fix: #213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
 - Updated documentation:
   - Added note in TESTING.md about script templates.
 
+### Fixed
+
+- [#213][GDScript] Method names in verbose mode display "([])" when there are no arguments
+
 ### Removed
 
 - '>' character from test output.

--- a/addons/confirma/src/helpers/CollectionHelper.cs
+++ b/addons/confirma/src/helpers/CollectionHelper.cs
@@ -16,7 +16,7 @@ public static class CollectionHelper
     {
         if (depth > maxDepth || !collection.Any())
         {
-            return "[]";
+            return addBrackets ? "[]" : string.Empty;
         }
 
         List<string> list = new();


### PR DESCRIPTION
## Description:

### What does this PR do?

Adds a missing check in `CollectionHelper.cs` if `addBrackets` is `true`
then returns "[]" or string.Empty

### Why is this change necessary?

#213 

### What issues does this PR fix/close?

fixes #213 

## Testing:

### How was this PR tested?

with ```"$GODOTdev" --headless -- --confirma-run --confirma-verbose```

### Are there any known issues or edge cases?

N/A

## Checklist:

- [x] Code is formatted correctly.
- [x] Documentation is updated (if necessary).
- [x] Changelog is updated (if necessary).
- [x] All new and existing tests passed (unit and E2E tests).
