### PR TITLE
feat: add type hint to collection helper & formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Support for flaky tests.
 - Ability to ignore tests in headless mode.
 - Support for test methods with `params` modifier.
+- Flag to `CollectionHelper.ToString` & `CollectionFormatter` for adding type hint.
 
 ### Changed
 
@@ -50,6 +51,7 @@ flaky tests, fuzz testing & `params` modifier.
 - Adjusted `Repeat` attribute to handle flaky tests.
 - Optimized `ConfirmElementsAreOrdered<T>` and `ConfirmElementsAreEquivalent<T>`
 in `ConfirmIEnumerableExtensions`.
+- String representation of arrays also displays their type.
 
 ### Removed
 

--- a/addons/confirma/src/formatters/CollectionFormatter.cs
+++ b/addons/confirma/src/formatters/CollectionFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,6 +11,8 @@ namespace Confirma.Formatters;
 public class CollectionFormatter : Formatter
 {
     private readonly bool _addTypeHint;
+    private static readonly ConcurrentDictionary<Type, Type?> ElementTypeCache = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo> ToStringMethodCache = new();
 
     public CollectionFormatter(bool addTypeHint = true)
     {
@@ -25,64 +28,90 @@ public class CollectionFormatter : Formatter
 
         if (value is IEnumerable enumerable && value is not string)
         {
-            Type? elementType = value.GetType().GetInterfaces()
-                .Where(static t => t.IsGenericType
-                    && t.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                )
-                .Select(static t => t.GetGenericArguments()[0])
-                .FirstOrDefault();
-
+            Type collectionType = value.GetType();
+            Type? elementType = GetElementType(collectionType);
             if (elementType is null)
             {
-                // Fallback if unable to determine element type
-                return CollectionHelper.ToString(
-                    enumerable.Cast<object?>(),
-                    depth: 0,
-                    maxDepth: 1,
-                    addBrackets: true,
-                    addTypeHint: _addTypeHint
-                );
+                return FormatFallback(enumerable);
             }
 
-            // The signature of the CollectionHelper.ToString method
-            Type[] methodParamTypes = new Type[]
-            {
-                typeof(IEnumerable<>).MakeGenericType(elementType), // IEnumerable<T>
-                typeof(uint),                                       // depth
-                typeof(uint),                                       // maxDepth
-                typeof(bool),                                       // addBrackets
-                typeof(bool)                                        // addTypeHint
-            };
-
-            MethodInfo? toStringMethod = typeof(CollectionHelper)
-                .GetMethods(BindingFlags.Static | BindingFlags.Public)
-                .FirstOrDefault(
-                    static m => m.Name == nameof(CollectionHelper.ToString)
-                    && m.IsGenericMethod
-                );
-
-            if (toStringMethod is not null)
-            {
-                toStringMethod = toStringMethod.MakeGenericMethod(elementType);
-
-                object[] parameters = new object[]
-                {
-                    value,       // The collection
-                    (uint)0,     // depth
-                    (uint)1,     // maxDepth
-                    true,        // addBrackets
-                    _addTypeHint // addTypeHint
-                };
-
-                object? result = toStringMethod.Invoke(null, parameters);
-
-                if (result is string strResult)
-                {
-                    return strResult;
-                }
-            }
+            MethodInfo? toStringMethod = GetToStringMethod(elementType);
+            return toStringMethod is not null
+                ? InvokeToStringMethod(toStringMethod, value)
+                : new DefaultFormatter().Format(value);
         }
 
         return new DefaultFormatter().Format(value);
+    }
+
+    private static Type? GetElementType(Type collectionType)
+    {
+        if (ElementTypeCache.TryGetValue(collectionType, out Type? elementType))
+        {
+            return elementType;
+        }
+
+        elementType = collectionType.GetInterfaces()
+            .FirstOrDefault(
+                static t => t.IsGenericType
+                && t.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            )
+            ?.GetGenericArguments()[0];
+
+        ElementTypeCache[collectionType] = elementType;
+
+        return elementType;
+    }
+
+    private MethodInfo? GetToStringMethod(Type elementType)
+    {
+        if (ToStringMethodCache.TryGetValue(
+            elementType,
+            out MethodInfo? toStringMethod)
+        )
+        {
+            return toStringMethod;
+        }
+
+        MethodInfo? genericMethod = typeof(CollectionHelper)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public)
+            .FirstOrDefault(
+                static m => m.Name == nameof(CollectionHelper.ToString)
+                && m.IsGenericMethod
+            );
+
+        if (genericMethod is not null)
+        {
+            toStringMethod = genericMethod.MakeGenericMethod(elementType);
+            ToStringMethodCache[elementType] = toStringMethod;
+        }
+
+        return toStringMethod;
+    }
+
+    private string FormatFallback(IEnumerable enumerable)
+    {
+        return CollectionHelper.ToString(
+            enumerable.Cast<object?>(),
+            depth: 0,
+            maxDepth: 1,
+            addBrackets: true,
+            addTypeHint: _addTypeHint
+        );
+    }
+
+    private string InvokeToStringMethod(MethodInfo toStringMethod, object value)
+    {
+        object[] parameters = new[]
+        {
+            value,       // The collection
+            (uint)0,     // depth
+            (uint)1,     // maxDepth
+            true,        // addBrackets
+            _addTypeHint // addTypeHint
+        };
+        return toStringMethod.Invoke(null, parameters) is string strResult
+            ? strResult
+            : new DefaultFormatter().Format(value);
     }
 }

--- a/addons/confirma/src/formatters/CollectionFormatter.cs
+++ b/addons/confirma/src/formatters/CollectionFormatter.cs
@@ -1,24 +1,88 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Confirma.Helpers;
 
 namespace Confirma.Formatters;
 
 public class CollectionFormatter : Formatter
 {
+    private readonly bool _addTypeHint;
+
+    public CollectionFormatter(bool addTypeHint = true)
+    {
+        _addTypeHint = addTypeHint;
+    }
+
     public override string Format(object? value)
     {
-        if (value is ICollection<object?> c)
+        if (value is null)
         {
-            return CollectionHelper.ToString(c);
+            return new DefaultFormatter().Format(value);
         }
-        else if (value is IEnumerable b and not string)
-        {
-            IEnumerable<object?> array = b.Cast<object?>();
 
-            return CollectionHelper.ToString(array);
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            Type? elementType = value.GetType().GetInterfaces()
+                .Where(static t => t.IsGenericType
+                    && t.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                )
+                .Select(static t => t.GetGenericArguments()[0])
+                .FirstOrDefault();
+
+            if (elementType is null)
+            {
+                // Fallback if unable to determine element type
+                return CollectionHelper.ToString(
+                    enumerable.Cast<object?>(),
+                    depth: 0,
+                    maxDepth: 1,
+                    addBrackets: true,
+                    addTypeHint: _addTypeHint
+                );
+            }
+
+            // The signature of the CollectionHelper.ToString method
+            Type[] methodParamTypes = new Type[]
+            {
+                typeof(IEnumerable<>).MakeGenericType(elementType), // IEnumerable<T>
+                typeof(uint),                                       // depth
+                typeof(uint),                                       // maxDepth
+                typeof(bool),                                       // addBrackets
+                typeof(bool)                                        // addTypeHint
+            };
+
+            MethodInfo? toStringMethod = typeof(CollectionHelper)
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .FirstOrDefault(
+                    static m => m.Name == nameof(CollectionHelper.ToString)
+                    && m.IsGenericMethod
+                );
+
+            if (toStringMethod is not null)
+            {
+                toStringMethod = toStringMethod.MakeGenericMethod(elementType);
+
+                object[] parameters = new object[]
+                {
+                    value,       // The collection
+                    (uint)0,     // depth
+                    (uint)1,     // maxDepth
+                    true,        // addBrackets
+                    _addTypeHint // addTypeHint
+                };
+
+                object? result = toStringMethod.Invoke(null, parameters);
+
+                if (result is string strResult)
+                {
+                    return strResult;
+                }
+            }
         }
+
         return new DefaultFormatter().Format(value);
     }
 }

--- a/addons/confirma/src/helpers/CollectionHelper.cs
+++ b/addons/confirma/src/helpers/CollectionHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Confirma.Formatters;
 
 namespace Confirma.Helpers;
@@ -21,32 +22,41 @@ public static class CollectionHelper
             return addBrackets ? typeName + "[]" : string.Empty;
         }
 
-        List<string> list = new();
+        StringBuilder sb = new();
 
         foreach (T item in collection)
         {
             if (item is null)
             {
-                list.Add("null");
-                continue;
+                _ = sb.Append("null");
             }
-
-            if (item is IEnumerable<object> e && item is not string)
+            else if (item is IEnumerable<object> e && item is not string)
             {
                 if (depth + 1 > maxDepth)
                 {
-                    list.Add(typeName + "[...]");
-                    continue;
+                    _ = sb.Append(typeName + "[...]");
                 }
-
-                string result = ToString(e, depth + 1, maxDepth, addBrackets: false);
-                list.Add(typeName + $"[{string.Join(", ", result)}]");
-                continue;
+                else
+                {
+                    string result = ToString(e, depth + 1, maxDepth, false, false);
+                    _ = sb.Append(typeName + $"[{string.Join(", ", result)}]");
+                }
+            }
+            else
+            {
+                _ = sb.Append(new AutomaticFormatter().Format(item));
             }
 
-            list.Add(new AutomaticFormatter().Format(item));
+            _ = sb.Append(", ");
         }
-        string text = string.Join(", ", list);
+
+        // Remove the trailing comma and space
+        if (sb.Length > 2)
+        {
+            sb.Length -= 2;
+        }
+
+        string text = sb.ToString();
 
         return addBrackets ? typeName + $"[{text}]" : text;
     }

--- a/addons/confirma/src/helpers/CollectionHelper.cs
+++ b/addons/confirma/src/helpers/CollectionHelper.cs
@@ -10,13 +10,15 @@ public static class CollectionHelper
         IEnumerable<T> collection,
         uint depth = 0,
         uint maxDepth = 1,
-        bool addBrackets = true
-
+        bool addBrackets = true,
+        bool addTypeHint = true
     )
     {
+        string typeName = addTypeHint ? typeof(T).Name : string.Empty;
+
         if (depth > maxDepth || !collection.Any())
         {
-            return addBrackets ? "[]" : string.Empty;
+            return addBrackets ? typeName + "[]" : string.Empty;
         }
 
         List<string> list = new();
@@ -33,12 +35,12 @@ public static class CollectionHelper
             {
                 if (depth + 1 > maxDepth)
                 {
-                    list.Add("[...]");
+                    list.Add(typeName + "[...]");
                     continue;
                 }
 
                 string result = ToString(e, depth + 1, maxDepth, addBrackets: false);
-                list.Add($"[{string.Join(", ", result)}]");
+                list.Add(typeName + $"[{string.Join(", ", result)}]");
                 continue;
             }
 
@@ -46,6 +48,6 @@ public static class CollectionHelper
         }
         string text = string.Join(", ", list);
 
-        return addBrackets ? $"[{text}]" : text;
+        return addBrackets ? typeName + $"[{text}]" : text;
     }
 }

--- a/tests/classes/TestCaseTest.cs
+++ b/tests/classes/TestCaseTest.cs
@@ -123,7 +123,7 @@ public class TestCaseTest
         object?[] p = new TestCase(method, new object[] { 1, 2, 3 }, null).Parameters!;
 
         _ = p.ConfirmCount(1);
-        _ = p[0].ConfirmEqual(new object[] { 1, 2, 3 });
+        _ = p[0].ConfirmEqual(new int[] { 1, 2, 3 });
     }
 
     [TestCase]
@@ -145,7 +145,7 @@ public class TestCaseTest
 
         _ = p.ConfirmCount(2);
         _ = p[0].ConfirmEqual(true);
-        _ = p[1].ConfirmEqual(new object[] { 1, 2, 3 });
+        _ = p[1].ConfirmEqual(new int[] { 1, 2, 3 });
     }
 
     [TestCase]
@@ -158,7 +158,7 @@ public class TestCaseTest
 
         _ = p.ConfirmCount(2);
         _ = p[0].ConfirmEqual(true);
-        _ = p[1].ConfirmEqual(Array.Empty<object>());
+        _ = p[1].ConfirmEqual(Array.Empty<int>());
     }
     #endregion GenerateArguments
 }

--- a/tests/extensions/ConfirmEqualTest.cs
+++ b/tests/extensions/ConfirmEqualTest.cs
@@ -73,7 +73,7 @@ public class ConfirmEqualTest
 
         _ = action.ConfirmThrowsWMessage<ConfirmAssertException>(
             "Assertion ConfirmEqual failed: "
-            + "Expected [1, 2, 3], but got [0, 1, 2]."
+            + "Expected Object[1, 2, 3], but got Object[0, 1, 2]."
         );
     }
 
@@ -143,7 +143,7 @@ public class ConfirmEqualTest
 
         _ = action.ConfirmThrowsWMessage<ConfirmAssertException>(
             "Assertion ConfirmNotEqual failed: "
-            + "Expected not [\"Hello,\", \"world!\"]."
+            + "Expected not String[\"Hello,\", \"world!\"]."
         );
     }
 
@@ -159,7 +159,7 @@ public class ConfirmEqualTest
         };
 
         _ = action.ConfirmThrowsWMessage<ConfirmAssertException>(
-            "Assertion ConfirmNotEqual failed: Expected not [0, 1, 2]."
+            "Assertion ConfirmNotEqual failed: Expected not Object[0, 1, 2]."
         );
     }
     #endregion ConfirmNotEqual

--- a/tests/extensions/ConfirmReferenceTest.cs
+++ b/tests/extensions/ConfirmReferenceTest.cs
@@ -22,9 +22,9 @@ public class ConfirmReferenceTest
     [TestCase(5, "5", 15, "15")]
     [TestCase(
         new byte[] { 1, 2, 3 },
-        "[1, 2, 3]",
+        "Byte[1, 2, 3]",
         new byte[] { 1, 2, 3 },
-        "[1, 2, 3]"
+        "Byte[1, 2, 3]"
     )]
     [TestCase(
         "Lorem ipsum",
@@ -61,7 +61,7 @@ public class ConfirmReferenceTest
     }
 
     [TestCase(5, "5")]
-    [TestCase(new byte[] { 1, 2, 3 }, "[1, 2, 3]")]
+    [TestCase(new byte[] { 1, 2, 3 }, "Byte[1, 2, 3]")]
     [TestCase(
         "Lorem ipsum dolor sit amet",
         "\"Lorem ipsum dolor sit amet\""

--- a/tests/formatters/AutomaticFormatterTest.cs
+++ b/tests/formatters/AutomaticFormatterTest.cs
@@ -16,7 +16,7 @@ public class AutomaticFormatterTest
     [TestCase(12345u, "12,345")]
     [TestCase((byte)123, "123")]
     [TestCase(123.456f, "123.45600")]
-    [TestCase(new int[] { 1, 2, 3 }, "[1, 2, 3]")]
+    [TestCase(new int[] { 1, 2, 3 }, "Int32[1, 2, 3]")]
     [TestCase("Hello, World!", "\"Hello, World!\"")]
     public void Format_CorrectlyFormatsSupportedTypes(
         object actual,

--- a/tests/formatters/CollectionFormatterTest.cs
+++ b/tests/formatters/CollectionFormatterTest.cs
@@ -25,7 +25,7 @@ public class CollectionFormatterTest
         IEnumerable<object> value = Enumerable.Empty<object>();
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[]");
+        _ = result.ConfirmEqual("Object[]");
     }
 
     [TestCase]
@@ -34,7 +34,7 @@ public class CollectionFormatterTest
         IEnumerable<string> value = new[] { "Hello" };
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[\"Hello\"]");
+        _ = result.ConfirmEqual("String[\"Hello\"]");
     }
 
     [TestCase]
@@ -43,7 +43,7 @@ public class CollectionFormatterTest
         List<float> value = new() { 20f, 25f };
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[20.00000, 25.00000]");
+        _ = result.ConfirmEqual("Single[20.00000, 25.00000]");
     }
 
     [TestCase]
@@ -52,7 +52,7 @@ public class CollectionFormatterTest
         float[] value = Array.Empty<float>();
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[]");
+        _ = result.ConfirmEqual("Single[]");
     }
 
     [TestCase]
@@ -61,7 +61,7 @@ public class CollectionFormatterTest
         object[] value = new[] { "Hello" };
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[\"Hello\"]");
+        _ = result.ConfirmEqual("String[\"Hello\"]");
     }
 
     [TestCase]
@@ -70,7 +70,7 @@ public class CollectionFormatterTest
         object[] value = new[] { "Hello", "World" };
         string result = _formatter!.Format(value);
 
-        _ = result.ConfirmEqual("[\"Hello\", \"World\"]");
+        _ = result.ConfirmEqual("String[\"Hello\", \"World\"]");
     }
 
     [TestCase]

--- a/tests/formatters/VariantFormatterTest.cs
+++ b/tests/formatters/VariantFormatterTest.cs
@@ -46,6 +46,6 @@ public class VariantFormatterTest
     {
         _ = _formatter
             .Format(new int[] { 1, 2, 3 })
-            .ConfirmEqual("[1, 2, 3]");
+            .ConfirmEqual("Int32[1, 2, 3]");
     }
 }

--- a/tests/helpers/CollectionHelperTest.cs
+++ b/tests/helpers/CollectionHelperTest.cs
@@ -14,7 +14,7 @@ public class CollectionHelperTest
     public void ToString_EmptyEnumerable_ReturnsEmptyArrayString()
     {
         IEnumerable<object> value = Enumerable.Empty<object>();
-        _ = CollectionHelper.ToString(value).ConfirmEqual("[]");
+        _ = CollectionHelper.ToString(value).ConfirmEqual("Object[]");
     }
 
     [TestCase]
@@ -31,7 +31,7 @@ public class CollectionHelperTest
     {
         IEnumerable<string> value = new[] { "Hello" };
 
-        _ = CollectionHelper.ToString(value).ConfirmEqual("[\"Hello\"]");
+        _ = CollectionHelper.ToString(value).ConfirmEqual("String[\"Hello\"]");
     }
 
     [TestCase]
@@ -39,7 +39,8 @@ public class CollectionHelperTest
     {
         List<float> value = new() { 20f, 25f };
 
-        _ = CollectionHelper.ToString(value).ConfirmEqual("[20.00000, 25.00000]");
+        _ = CollectionHelper.ToString(value)
+            .ConfirmEqual("Single[20.00000, 25.00000]");
     }
 
     [TestCase]
@@ -47,7 +48,7 @@ public class CollectionHelperTest
     {
         object[] value = new[] { "Hello" };
 
-        _ = CollectionHelper.ToString(value).ConfirmEqual("[\"Hello\"]");
+        _ = CollectionHelper.ToString(value).ConfirmEqual("Object[\"Hello\"]");
     }
 
     [TestCase]
@@ -55,7 +56,8 @@ public class CollectionHelperTest
     {
         object[] value = new[] { "Hello", "World" };
 
-        _ = CollectionHelper.ToString(value).ConfirmEqual("[\"Hello\", \"World\"]");
+        _ = CollectionHelper.ToString(value)
+            .ConfirmEqual("Object[\"Hello\", \"World\"]");
     }
 
     [TestCase]
@@ -66,5 +68,14 @@ public class CollectionHelperTest
         _ = CollectionHelper
             .ToString(value, addBrackets: false)
             .ConfirmEqual("\"Hello\"");
+    }
+
+    [TestCase]
+    public void ToString_NoTypeHint_EmptyEnumerable_ReturnsEmptyArrayString()
+    {
+        IEnumerable<object> value = Enumerable.Empty<object>();
+        _ = CollectionHelper
+            .ToString(value, addTypeHint: false)
+            .ConfirmEqual("[]");
     }
 }


### PR DESCRIPTION
## Description:

### What does this PR do?

Adds type hint to collection helper & formatter.

Before: `[1, 2, 3]`

After: `Int32[1, 2, 3,]`

### Why is this change necessary?

Sometimes it's hard to determine how a specific array is treated.

### What issues does this PR fix/close?

N/A

## Testing:

### How was this PR tested?

- unit testing
- manual testing

### Are there any known issues or edge cases?

No.

## Checklist:

- [x] Code is formatted correctly.
- [x] Documentation is updated (if necessary).
- [x] Changelog is updated (if necessary).
- [x] All new and existing tests passed (unit and E2E tests).
